### PR TITLE
Fix evaluation of sci notation with multi-digit base

### DIFF
--- a/src/calc.pest
+++ b/src/calc.pest
@@ -5,7 +5,7 @@ WHITESPACE = _{ " " | "\t" }
 COMMENT = { "#" ~ ANY* }
 
 int = { uint }
-fulluint = @{ ASCII_DIGIT ~ ^"e" ~ "+"? ~ uint }
+fulluint = @{ ASCII_DIGIT+ ~ ^"e" ~ "+"? ~ uint }
 hex = @{ "0" ~ ^"x" ~ ASCII_HEX_DIGIT+ }
 oct = @{ "0" ~ ^"o" ~ ASCII_OCT_DIGIT+ }
 bin = @{ "0" ~ ^"b" ~ ASCII_BIN_DIGIT+ }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -369,6 +369,12 @@ mod tests {
         assert_eq!(v, Ok(Value::Int(BigInt::from(7))));
         let v = eval("1 + sin cos 2 * 10", &mut state);
         assert_eq!(v, Ok(Value::Float(2.0f64.cos().sin() * 10.0 + 1.0)));
+        let v = eval("1e3", &mut state);
+        assert_eq!(v, Ok(Value::Int(BigInt::from(1000))));
+        let v = eval("10e3", &mut state);
+        assert_eq!(v, Ok(Value::Int(BigInt::from(10000))));
+        let v = eval("10.5e3", &mut state);
+        assert_eq!(v, Ok(Value::Float(10500f64)));
         let v = eval("20 + 50 %", &mut state);
         assert_eq!(v, Ok(Value::Int(BigInt::from(30))));
         let v = eval("40 + 30 - 50 %", &mut state);


### PR DESCRIPTION
Evaluating an expression with a multi-digit integer scientific notation base such as

```
10e2
```

Would result in an error "Variable 'e2' not found".